### PR TITLE
Fix build errors with clang

### DIFF
--- a/natural_sort.hpp
+++ b/natural_sort.hpp
@@ -60,6 +60,7 @@ namespace natural
 					return -1;
 				if(natural_less<ElementType>(*rhs,*lhs))
 					return +1;
+				return 0;
 			}
 		};
 	

--- a/natural_sort.hpp
+++ b/natural_sort.hpp
@@ -247,25 +247,25 @@ namespace natural
 
 
 	template<typename Container>
-	inline bool sort(Container &container)
+	inline void sort(Container &container)
 	{
 		std::sort(container.begin(),container.end(),compare<typename Container::value_type>);
 	}
 
 	template<typename Iterator>
-	inline bool sort(const Iterator &first,const Iterator &end)
+	inline void sort(const Iterator &first,const Iterator &end)
 	{
 		std::sort(first,end,compare<typename Iterator::value_type>);
 	}
 	
 	template<typename ValueType>
-	inline bool sort(ValueType* const first,ValueType* const end)
+	inline void sort(ValueType* const first,ValueType* const end)
 	{
 		std::sort(first,end,compare<ValueType>);
 	}
 
 	template<typename ValueType,int N>
-	inline bool sort(ValueType container[N])
+	inline void sort(ValueType container[N])
 	{
 		std::sort(&container[0],&container[0]+N,compare<ValueType>);
 	}

--- a/natural_sort.hpp
+++ b/natural_sort.hpp
@@ -227,7 +227,7 @@ namespace natural
 				current2 = last_nondigit2;
 			}
 		}
-
+		return current1 == lhsEnd;
 	}
 
 	template<typename String>

--- a/natural_sort_test.cpp
+++ b/natural_sort_test.cpp
@@ -7,7 +7,11 @@ int main()
 {	
 	std::vector<std::string> v;
 	std::string s;
-	std::cout<<"Comparision of \"Hello 32\" and \"Hello 023\" : "<<(SI::natural::compare<std::string>("Hello 32","Hello 023"))<<std::endl;
+	std::cout<<"Comparision of \"Hello 32\" and \"Hello 023\" : "<<(SI::natural::compare<std::string>("Hello 32","Hello 023"))<<" (Expected: 0)"<<std::endl;
+	std::cout<<"Comparision of \"Hello 32a\" and \"Hello 32\" : "<<(SI::natural::compare<std::string>("Hello 32a","Hello 32"))<<" (Expected: 0)"<<std::endl;
+	std::cout<<"Comparision of \"Hello 32\" and \"Hello 32a\" : "<<(SI::natural::compare<std::string>("Hello 32","Hello 32a"))<<" (Expected: 1)"<<std::endl;
+	std::cout<<"Comparision of \"Hello 32.1\" and \"Hello 32\" : "<<(SI::natural::compare<std::string>("Hello 32.1","Hello 32"))<<" (Expected: 0)"<<std::endl;
+	std::cout<<"Comparision of \"Hello 32\" and \"Hello 32.1\" : "<<(SI::natural::compare<std::string>("Hello 32","Hello 32.1"))<<" (Expected: 1)"<<std::endl;
 	while(getline(std::cin,s))
 		v.push_back(s);
 	std::vector<char *> v2;


### PR DESCRIPTION
clang fails to compile `natural_sort.hpp` by the following errors.
This change fixed the errors.

```
./natural_sort.hpp:63:4: warning: control may reach end of non-void function
./natural_sort.hpp:230:2: warning: control may reach end of non-void function
./natural_sort.hpp:252:2: warning: control reaches end of non-void function
./natural_sort.hpp:270:2: warning: control reaches end of non-void function
```
