### PR TITLE
Fix the result of compare(a,a)

### DIFF
--- a/natural_sort.hpp
+++ b/natural_sort.hpp
@@ -227,7 +227,12 @@ namespace natural
 				current2 = last_nondigit2;
 			}
 		}
-		return current1 == lhsEnd;
+
+		if (current1 == lhsEnd && current2 == rhsEnd) {
+			return false;
+		} else {
+			return current1 == lhsEnd;
+		}
 	}
 
 	template<typename String>

--- a/natural_sort_test.cpp
+++ b/natural_sort_test.cpp
@@ -12,6 +12,7 @@ int main()
 	std::cout<<"Comparision of \"Hello 32\" and \"Hello 32a\" : "<<(SI::natural::compare<std::string>("Hello 32","Hello 32a"))<<" (Expected: 1)"<<std::endl;
 	std::cout<<"Comparision of \"Hello 32.1\" and \"Hello 32\" : "<<(SI::natural::compare<std::string>("Hello 32.1","Hello 32"))<<" (Expected: 0)"<<std::endl;
 	std::cout<<"Comparision of \"Hello 32\" and \"Hello 32.1\" : "<<(SI::natural::compare<std::string>("Hello 32","Hello 32.1"))<<" (Expected: 1)"<<std::endl;
+	std::cout<<"Comparision of \"Hello 32\" and \"Hello 32\" : "<<(SI::natural::compare<std::string>("Hello 32","Hello 32"))<<" (Expected: 0)"<<std::endl;
 	while(getline(std::cin,s))
 		v.push_back(s);
 	std::vector<char *> v2;


### PR DESCRIPTION
My previous commit returns wrong result for compare(a, a).
It should be false, but it returns true.

This commit fixed the issue.
