### PR TITLE
bring sorting in line with os behavior

### DIFF
--- a/natural_sort.hpp
+++ b/natural_sort.hpp
@@ -196,9 +196,9 @@ namespace natural
 			if(*current2==' ') flag_found_space2 = true;
 			
 
-			if( !isdigit(*current1 ) && !isdigit(*current2))
+			if( !isdigit(*current1 ) || !isdigit(*current2))
 			{
-				//If Both Are Non Digits do Normal Comparision
+				// Normal comparision if any of character is non digit character
 				if(detail::natural_less<ElementType>(*current1,*current2))
 					return true;
 				if(detail::natural_less<ElementType>(*current2,*current1))


### PR DESCRIPTION
the results returned from the native macos/win32, as well as ls -v
performs a sorting that, numbers are less than letters, while in this
implementation, numbers are greater than letters.

this commit changes the behavior to use emulate the os behavor