### PR TITLE
Make skipping of leading 0's optional

### DIFF
--- a/natural_sort.hpp
+++ b/natural_sort.hpp
@@ -107,6 +107,7 @@ namespace natural
 			}
 			int non_fractional(Iterator lhsBegin,Iterator lhsEnd, Iterator rhsBegin,Iterator rhsEnd)
 			{
+#ifndef SI_sort_leading_0s
 				//Skip Inital Zero's
 				while(lhsBegin<lhsEnd && *lhsBegin=='0') lhsBegin++;
 				while(rhsBegin<rhsEnd && *rhsBegin=='0') rhsBegin++; 
@@ -116,6 +117,7 @@ namespace natural
 					return -1;
 				if(lhsEnd-lhsBegin>rhsEnd-rhsBegin)
 					return +1;
+#endif
 
 				//Equal In length
 				while(lhsBegin<lhsEnd)


### PR DESCRIPTION
Skipping them makes the comparisons a bit mathematically stricter in the
sense that they have the following properties:

(See https://sqlite.org/c3ref/create_collation.html)

    If A==B then B==A.
    If A==B and B==C then A==C.
    If A<B THEN B>A.
    If A<B and B<C then A<C.