### PR TITLE
Do consider leading 0's when comparing for equality

### DIFF
--- a/natural_sort.hpp
+++ b/natural_sort.hpp
@@ -74,9 +74,9 @@ namespace natural
 			);
 
 		Returns : 
-			-1  - Number1  <   Number2
+			<0  - Number1  <   Number2
 			 0  - Number1  ==  Number2
-			 1  - Number1  >   Number2
+			>0  - Number1  >   Number2
 
 		***************************************************/
 
@@ -85,6 +85,17 @@ namespace natural
 		struct compare_number
 		{
 		private:
+			int skipLeading0s(Iterator& begin, Iterator end)
+			{
+				int skippedLeading0s = 0;
+				while(begin<end && *begin=='0')
+				{
+					skippedLeading0s++;
+					begin++;
+				}
+				return skippedLeading0s;
+			}
+
 			//If Number is Itself fractional Part
 			int fractional(Iterator lhsBegin,Iterator lhsEnd, Iterator rhsBegin,Iterator rhsEnd)
 			{
@@ -96,20 +107,24 @@ namespace natural
 					lhsBegin++;
 					rhsBegin++;
 				}
-				while(lhsBegin<lhsEnd && *lhsBegin=='0') lhsBegin++;
-				while(rhsBegin<rhsEnd && *rhsBegin=='0') rhsBegin++;
+				const int lhsLeading0s = skipLeading0s(lhsBegin, lhsEnd);
+				const int rhsLeading0s = skipLeading0s(rhsBegin, rhsEnd);
 				if(lhsBegin==lhsEnd && rhsBegin!=rhsEnd)
 					return -1;
 				else if(lhsBegin!=lhsEnd && rhsBegin==rhsEnd)
 					return +1;
 				else //lhsBegin==lhsEnd && rhsBegin==rhsEnd
-					return 0;		
+#ifndef SI_sort_leading_0s
+					return 0;
+#else
+					return lhsLeading0s - rhsLeading0s;		// '.700' comes after '.7'
+#endif
 			}
 			int non_fractional(Iterator lhsBegin,Iterator lhsEnd, Iterator rhsBegin,Iterator rhsEnd)
 			{
 				//Skip Inital Zero's
-				while(lhsBegin<lhsEnd && *lhsBegin=='0') lhsBegin++;
-				while(rhsBegin<rhsEnd && *rhsBegin=='0') rhsBegin++; 
+				const int lhsLeading0s = skipLeading0s(lhsBegin, lhsEnd);
+				const int rhsLeading0s = skipLeading0s(rhsBegin, rhsEnd);
 		
 				//Comparing By Length of Both String
 				if(lhsEnd-lhsBegin<rhsEnd-rhsBegin)
@@ -126,7 +141,11 @@ namespace natural
 					lhsBegin++;
 					rhsBegin++;
 				}
+#ifndef SI_sort_leading_0s
 				return 0;
+#else
+				return rhsLeading0s - lhsLeading0s;			// '007' comes before plain old '7'
+#endif
 			}
 
 
@@ -157,10 +176,7 @@ namespace natural
 	/***********************************************************************
 	Natural Comparision of Two String using both's (Begin and End Iterator)
 
-	Returns : 
-		-1  - String1  <   String2
-		 0  - String1  ==  String2
-		 1  - String1  >   String2
+	Returns : true if  String1  <   String2
 
 	Suffix 1 represents for components of 1st String
 	Suffix 2 represents for components of 2nd String

--- a/natural_sort_test.cpp
+++ b/natural_sort_test.cpp
@@ -13,6 +13,11 @@ int main()
 	std::cout<<"Comparision of \"Hello 32.1\" and \"Hello 32\" : "<<(SI::natural::compare<std::string>("Hello 32.1","Hello 32"))<<" (Expected: 0)"<<std::endl;
 	std::cout<<"Comparision of \"Hello 32\" and \"Hello 32.1\" : "<<(SI::natural::compare<std::string>("Hello 32","Hello 32.1"))<<" (Expected: 1)"<<std::endl;
 	std::cout<<"Comparision of \"Hello 32\" and \"Hello 32\" : "<<(SI::natural::compare<std::string>("Hello 32","Hello 32"))<<" (Expected: 0)"<<std::endl;
+#ifdef SI_sort_leading_0s
+	std::cout<<"Comparision of \"Hello 032\" and \"Hello 32\" : "<<(SI::natural::compare<std::string>("Hello 032","Hello 32"))<<" (Expected: 1)"<<std::endl;
+	std::cout<<"Comparision of \"Hello 0032\" and \"Hello 33\" : "<<(SI::natural::compare<std::string>("Hello 0032","Hello 33"))<<" (Expected: 1)"<<std::endl;
+	std::cout<<"Comparision of \"Hello 32.1\" and \"Hello 32.100\" : "<<(SI::natural::compare<std::string>("Hello 32.1","Hello 32.100"))<<" (Expected: 1)"<<std::endl;
+#endif
 	while(getline(std::cin,s))
 		v.push_back(s);
 	std::vector<char *> v2;


### PR DESCRIPTION
This new behavior is activated by #defining SI_sort_leading_0s

Completely ignoring the leading 0's causes the comparisons to be
mathematically weak in that they don't exhibit the following
properties:

(See https://sqlite.org/c3ref/create_collation.html)

    If A==B then B==A.
    If A==B and B==C then A==C.
    If A<B THEN B>A.
    If A<B and B<C then A<C.